### PR TITLE
Switched from readability to defuddle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@electron/remote": "^2.1.2",
 				"@google/generative-ai": "^0.24.0",
-				"@mozilla/readability": "^0.6.0",
 				"@types/turndown": "^5.0.5",
 				"defuddle": "^0.6.6",
 				"mathml-to-latex": "^1.5.0",
@@ -779,15 +778,6 @@
 			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
 			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/@mozilla/readability": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
-			"integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14.0.0"
-			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
 				"@google/generative-ai": "^0.24.0",
 				"@mozilla/readability": "^0.6.0",
 				"@types/turndown": "^5.0.5",
+				"defuddle": "^0.6.6",
+				"mathml-to-latex": "^1.5.0",
 				"turndown": "^7.2.0"
 			},
 			"devDependencies": {
@@ -22,10 +24,24 @@
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.25.0",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4",
 				"uuid": "^11.1.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -50,6 +66,121 @@
 				"@codemirror/state": "^6.5.0",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@electron/get": {
@@ -1026,6 +1157,15 @@
 			"license": "ISC",
 			"peer": true
 		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+			"integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1049,6 +1189,16 @@
 			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/ajv": {
@@ -1114,6 +1264,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1209,6 +1366,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1273,6 +1444,19 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1297,6 +1481,41 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/cssstyle/node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -1313,6 +1532,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
@@ -1399,6 +1625,30 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/defuddle": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/defuddle/-/defuddle-0.6.6.tgz",
+			"integrity": "sha512-cexePkdZCwg8g1DHCV3xfE6DGTBeldtJct4/fOumYE/kx+sgoDg8yxjCxlC/Pss0v11G5CUFSUmf7fGJg249AA==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"mathml-to-latex": "^1.4.3",
+				"temml": "^0.11.2",
+				"turndown": "^7.2.0"
+			},
+			"peerDependencies": {
+				"jsdom": "^24.0.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/detect-node": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -1432,6 +1682,21 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/electron": {
@@ -1473,6 +1738,19 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -1488,7 +1766,6 @@
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -1499,8 +1776,36 @@
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1963,6 +2268,23 @@
 			"license": "ISC",
 			"peer": true
 		},
+		"node_modules/form-data": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -1986,12 +2308,61 @@
 			"license": "ISC",
 			"peer": true
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
@@ -2126,7 +2497,6 @@
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -2201,12 +2571,81 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"license": "BSD-2-Clause",
 			"peer": true
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/http2-wrapper": {
 			"version": "1.0.3",
@@ -2220,6 +2659,33 @@
 			},
 			"engines": {
 				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -2326,6 +2792,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2346,6 +2819,47 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "24.1.3",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+			"integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cssstyle": "^4.0.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.4.3",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.12",
+				"parse5": "^7.1.2",
+				"rrweb-cssom": "^0.7.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.4",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^2.11.2"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -2449,6 +2963,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC",
+			"peer": true
+		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -2461,6 +2982,25 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mathml-to-latex": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.5.0.tgz",
+			"integrity": "sha512-rrWn0eEvcEcdMM4xfHcSGIy+i01DX9byOdXTLWg+w1iJ6O6ohP5UXY1dVzNUZLhzfl3EGcRekWLhY7JT5Omaew==",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.8.10"
 			}
 		},
 		"node_modules/merge2": {
@@ -2485,6 +3025,29 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -2547,6 +3110,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.22",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+			"integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
@@ -2661,6 +3231,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2745,6 +3328,19 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -2760,12 +3356,18 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -2813,6 +3415,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/resolve-alpn": {
 			"version": "1.2.1",
@@ -2893,6 +3502,13 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2915,6 +3531,26 @@
 			"license": "MIT",
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/semver": {
@@ -3075,6 +3711,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/temml": {
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/temml/-/temml-0.11.11.tgz",
+			"integrity": "sha512-Z/Ihgwad+ges0ez6+KmKWZ3o4BYbP6aZ/cU94cVtN+DwxwqxjHgcF4Z6cb9jLkKN+aU7uni165HsIxLHs5/TqA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18.13.0"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3094,6 +3747,45 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/tslib": {
@@ -3205,6 +3897,17 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/uuid": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -3226,6 +3929,66 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -3260,6 +4023,45 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ws": {
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	"dependencies": {
 		"@electron/remote": "^2.1.2",
 		"@google/generative-ai": "^0.24.0",
-		"@mozilla/readability": "^0.6.0",
 		"@types/turndown": "^5.0.5",
 		"defuddle": "^0.6.6",
 		"mathml-to-latex": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
+		"dev-build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
@@ -28,6 +29,8 @@
 		"@google/generative-ai": "^0.24.0",
 		"@mozilla/readability": "^0.6.0",
 		"@types/turndown": "^5.0.5",
+		"defuddle": "^0.6.6",
+		"mathml-to-latex": "^1.5.0",
 		"turndown": "^7.2.0"
 	}
 }

--- a/src/Extractors/helper.ts
+++ b/src/Extractors/helper.ts
@@ -1,236 +1,757 @@
+import { MathMLToLaTeX } from 'mathml-to-latex';
+import TurndownService from 'turndown';
 import WebClipperPlugin from '../main';
+import { processUrls } from './string-utils';
+
+/*
+MIT License
+
+Copyright (c) 2024 Obsidian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 
 export class ProcessNodeHelper {
   private plugin: WebClipperPlugin;
-  private recentLinks: Set<string> = new Set();
-  private seenImages: Set<string> = new Set();
+  private footnotes: { [key: string]: string } = {};
 
   constructor(plugin: WebClipperPlugin) {
     this.plugin = plugin;
   }
 
   resetProcessingFlags(): void {
-    this.seenImages.clear();
-    this.recentLinks.clear();
+      this.footnotes = {};
   }
 
-  processNode(node: Node, baseUrl: string): string {
-    if (node.nodeType === Node.TEXT_NODE) {
-      return (node.textContent || '').trim();
+  processNode(node: Element | string, url: string): string {
+    let content: string;
+    if (typeof node == "string") {
+        content = node;
+    } else {
+        content = node.outerHTML;
     }
 
-    if (!(node instanceof HTMLElement)) {
-      return '';
-    }
+    console.debug('Markdown', 'Starting markdown conversion for URL:', url);
+    console.debug('Markdown', 'Content length:', content.length);
 
-    const element = node as HTMLElement;
-    return this.processElement(element, baseUrl);
-  }
+    const baseUrl = new URL(url);
+    // Process all URLs at the beginning
+    const processedContent = processUrls(content, baseUrl);
 
-  private processElement(element: HTMLElement, baseUrl: string): string {
-    const tagProcessors: Record<string, (el: HTMLElement) => string> = {
-      BLOCKQUOTE: (el) => this.processBlockquote(el, baseUrl),
-      A: (el) => this.processAnchor(el, baseUrl),
-      STRONG: (el) => this.processWrappedContent(el, baseUrl, '**'),
-      EM: (el) => this.processWrappedContent(el, baseUrl, '*'),
-      H1: (el) => this.processHeading(el, baseUrl, 1),
-      H2: (el) => this.processHeading(el, baseUrl, 2),
-      H3: (el) => this.processHeading(el, baseUrl, 3),
-      H4: (el) => this.processHeading(el, baseUrl, 4),
-      H5: (el) => this.processHeading(el, baseUrl, 5),
-      H6: (el) => this.processHeading(el, baseUrl, 6),
-      TABLE: (el) => this.processTable(el as HTMLTableElement, baseUrl),
-      UL: (el) => this.processList(el, baseUrl, 'ul'),
-      OL: (el) => this.processList(el, baseUrl, 'ol'),
-      P: (el) => this.processParagraph(el, baseUrl),
-      BR: () => '\n',
-      HR: () => '---\n\n',
-      IMG: (el) => this.processImage(el as HTMLImageElement, baseUrl),
-      IFRAME: (el) => this.processIframe(el),
-      VIDEO: (el) => this.processVideo(el),
-      CODE: (el) => this.processCode(el),
-      PRE: (el) => this.processPre(el, baseUrl),
-    };
+    const turndownService = new TurndownService({
+      headingStyle: 'atx',
+      hr: '---',
+      bulletListMarker: '-',
+      codeBlockStyle: 'fenced',
+      emDelimiter: '*',
+      preformattedCode: true,
+    });
 
-    const processor = tagProcessors[element.tagName];
-    if (processor) {
-      return processor(element);
-    }
+    turndownService.addRule('table', {
+      filter: 'table',
+      replacement: function(content, node) {
+        if (!(node instanceof HTMLTableElement)) return content;
 
-    return Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('');
-  }
+        // Check if it's an ArXiv equation table
+        if (node.classList.contains('ltx_equation') || node.classList.contains('ltx_eqn_table')) {
+          return handleNestedEquations(node);
+        }
 
-  private processBlockquote(element: HTMLElement, baseUrl: string): string {
-    const content = Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('')
-      .trim();
-    return content ? `> ${content.replace(/\n/g, '\n> ')}\n\n` : '';
-  }
-
-  private processAnchor(element: HTMLElement, baseUrl: string): string {
-    const href = element.getAttribute('href');
-    const text = element.textContent?.trim() || '';
-
-    if (!href || !text) return text;
-
-    const absoluteLink = this.resolveUrl(baseUrl, href);
-    const linkKey = `${text}:${absoluteLink}`;
-
-    if (this.recentLinks.has(linkKey)) return text;
-
-    this.recentLinks.add(linkKey);
-    if (this.recentLinks.size > 10) {
-      const oldestLink = this.recentLinks.values().next().value;
-      this.recentLinks.delete(oldestLink);
-    }
-
-    const prefixSpace = this.shouldAddSpace(element.previousSibling) || '';
-    const suffixSpace = this.shouldAddSpace(element.nextSibling) || '';
-    
-    const needsPrefixSpace = prefixSpace === '' && 
-      (element.previousSibling?.nodeType === Node.TEXT_NODE || 
-       element.previousSibling instanceof HTMLElement);
-    
-    const needsSuffixSpace = suffixSpace === '' && 
-      (element.nextSibling?.nodeType === Node.TEXT_NODE || 
-       element.nextSibling instanceof HTMLElement);
-
-    return `${needsPrefixSpace ? ' ' : ''}[${text}](${absoluteLink})${needsSuffixSpace ? ' ' : ''}`;
-  }
-
-  private processWrappedContent(element: HTMLElement, baseUrl: string, wrapper: string): string {
-    const content = Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('');
-    return `${wrapper}${content}${wrapper}`;
-  }
-
-  private processHeading(element: HTMLElement, baseUrl: string, level: number): string {
-    const content = Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('');
-    return `${'#'.repeat(level)} ${content}\n\n`;
-  }
-
-  private processTable(table: HTMLTableElement, baseUrl: string): string {
-    let content = '\n';
-    const rows = table.rows;
-    const columnCount = Math.max(...Array.from(rows).map((row) => row.cells.length));
-
-
-    if (rows.length > 0) {
-      const headerRow = rows[0];
-      content += '|' + Array.from(headerRow.cells)
-        .map((cell) => this.processNode(cell, baseUrl).replace(/\|/g, '\\|').trim())
-        .join('|') + '|\n';
-      content += '|' + Array(columnCount).fill('---').join('|') + '|\n';
-    }
-
-    for (let i = 1; i < rows.length; i++) {
-      content += '|' + Array.from(rows[i].cells)
-        .map((cell) => this.processNode(cell, baseUrl).replace(/\|/g, '\\|').trim())
-        .join('|') + '|\n';
-    }
-
-    return content + '\n';
-  }
-
-  private processList(element: HTMLElement, baseUrl: string, type: 'ul' | 'ol'): string {
-    const listItems = Array.from(element.childNodes)
-      .filter((child) => child.nodeName === 'LI')
-      .map((child, index) => {
-        const content = this.processNode(child, baseUrl).trim();
-        return type === 'ul' ? `- ${content}` : `${index + 1}. ${content}`;
-      });
-    return listItems.join('\n') + '\n\n';
-  }
-
-  private processParagraph(element: HTMLElement, baseUrl: string): string {
-    const content = Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('');
-    return `${content}\n\n`;
-  }
-
-  private resolveUrl(baseUrl: string, href: string): string {
-    try {
-      return new URL(href, baseUrl).toString();
-    } catch {
-      return href; 
-    }
-  }
-
-  private shouldAddSpace(sibling: Node | null): string {
-    if (!sibling) return '';
-    
-    if (sibling.nodeType === Node.TEXT_NODE) {
-      const text = sibling.textContent || '';
-      return /\S$/.test(text) ? ' ' : '';
-    }
-    
-    if (sibling instanceof HTMLElement) {
-      const blockElements = ['P', 'DIV', 'BR', 'HR', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
-      return blockElements.includes(sibling.tagName) ? ' ' : '';
-    }
-    
-    return '';
-  }
-
-  private processImage(element: HTMLImageElement, baseUrl: string): string {
-    const crossOrigin = element.hasAttribute('crossorigin') 
-        ? element.getAttribute('crossorigin')
-        : 'anonymous';
-
-
-    const dataSrcSet = element.getAttribute('data-lazy-srcset') || element.getAttribute('data-srcset');
-    let src = '';
-    
-    if (dataSrcSet) {
-        const urls = dataSrcSet.split(',').map(entry => {
-            const [url, size] = entry.trim().split(' ');
-            return { url: this.resolveUrl(baseUrl, url), size };
-        });
-        const httpsUrl = urls.find(u => u.url.startsWith('https://'));
-        src = httpsUrl?.url || '';
-    }
-    
-    if (!src) {
-        src = this.resolveUrl(baseUrl, 
-            element.getAttribute('data-src') || 
-            element.getAttribute('src') || 
-            ''
+        // Check if the table has colspan or rowspan
+        const hasComplexStructure = Array.from(node.querySelectorAll('td, th')).some(cell => 
+          cell.hasAttribute('colspan') || cell.hasAttribute('rowspan')
         );
+
+        if (hasComplexStructure) {
+          // Clean up the table HTML
+          const cleanedTable = cleanupTableHTML(node);
+          return '\n\n' + cleanedTable + '\n\n';
+        }
+
+        // Process simple tables as before
+        const rows = Array.from(node.rows).map(row => {
+          const cells = Array.from(row.cells).map(cell => {
+            // Remove newlines and trim the content
+            let cellContent = turndownService.turndown(ProcessNodeHelper.getElementHTML(cell))
+              .replace(/\n/g, ' ')
+              .trim();
+            // Escape pipe characters
+            cellContent = cellContent.replace(/\|/g, '\\|');
+            return cellContent;
+          });
+          return `| ${cells.join(' | ')} |`;
+        });
+
+        // Create the separator row
+        const separatorRow = `| ${Array(rows[0].split('|').length - 2).fill('---').join(' | ')} |`;
+
+        // Combine all rows
+        const tableContent = [rows[0], separatorRow, ...rows.slice(1)].join('\n');
+
+        return `\n\n${tableContent}\n\n`;
+      }
+    });
+
+    turndownService.remove(['style', 'script']);
+
+    // Keep iframes, video, audio, sup, and sub elements
+    // @ts-ignore
+    turndownService.keep(['iframe', 'video', 'audio', 'sup', 'sub', 'svg', 'math']);
+    turndownService.remove(['button']);
+
+    turndownService.addRule('list', {
+      filter: ['ul', 'ol'],
+      replacement: function (content: string, node: Node) {
+        // Remove trailing newlines/spaces from content
+        content = content.trim();
+        
+        // Add a newline before the list if it's a top-level list
+        const isTopLevel = !(node.parentNode && (node.parentNode.nodeName === 'UL' || node.parentNode.nodeName === 'OL'));
+        return (isTopLevel ? '\n' : '') + content + '\n';
+      }
+    });
+
+    // Lists with tab indentation
+    turndownService.addRule('listItem', {
+      filter: 'li',
+      replacement: function (content: string, node: Node, options: TurndownService.Options) {
+        if (!(node instanceof HTMLElement)) return content;
+
+        // Handle task list items
+        const isTaskListItem = node.classList.contains('task-list-item');
+        const checkbox = node.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+        let taskListMarker = '';
+        
+        if (isTaskListItem && checkbox) {
+          // Remove the checkbox from content since we'll add markdown checkbox
+          content = content.replace(/<input[^>]*>/, '');
+          taskListMarker = checkbox.checked ? '[x] ' : '[ ] ';
+        }
+
+        content = content
+          // Remove trailing newlines
+          .replace(/\n+$/, '')
+          // Split into lines
+          .split('\n')
+          // Remove empty lines
+          .filter(line => line.length > 0)
+          // Add indentation to continued lines
+          .join('\n\t');
+
+        let prefix = options.bulletListMarker + ' ';
+        let parent = node.parentNode;
+
+        // Calculate the nesting level
+        let level = 0;
+        let currentParent = node.parentNode;
+        while (currentParent && (currentParent.nodeName === 'UL' || currentParent.nodeName === 'OL')) {
+          level++;
+          currentParent = currentParent.parentNode;
+        }
+
+        // Add tab indentation based on nesting level, ensuring it's never negative
+        const indentLevel = Math.max(0, level - 1);
+        prefix = '\t'.repeat(indentLevel) + prefix;
+
+        if (parent instanceof HTMLOListElement) {
+          let start = parent.getAttribute('start');
+          let index = Array.from(parent.children).indexOf(node as HTMLElement) + 1;
+          prefix = '\t'.repeat(level - 1) + (start ? Number(start) + index - 1 : index) + '. ';
+        }
+
+        return prefix + taskListMarker + content.trim() + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
+      }
+    });
+
+    turndownService.addRule('figure', {
+      filter: 'figure',
+      replacement: function(content, node) {
+        const figure = node as HTMLElement;
+        const img = figure.querySelector('img');
+        const figcaption = figure.querySelector('figcaption');
+        
+        if (!img) return content;
+
+        const alt = img.getAttribute('alt') || '';
+        let src = img.getAttribute('src') || '';
+        const srcset = img.getAttribute('srcset') || '';
+
+        if (srcset) {
+
+          let images: {src: string, width: number}[] = [];
+
+          // deconstruct the srcset urls
+          const srcsetUrls = srcset.split(",%20");
+          for (let url of srcsetUrls) {
+
+            const split = url.split("%20");
+            const srcUrl = split[0];
+            const width = parseInt(split[1]);
+
+            images.push({src: srcUrl, width});
+          }
+
+          // we need to choose one of the images to use from the srcset
+          // for convenience, simply grab the first one
+          // this could be updated to take width into account
+
+          src = images[0].src;
+        }
+
+    
+        let caption = '';
+
+        if (figcaption) {
+          const tagSpan = figcaption.querySelector('.ltx_tag_figure');
+          const tagText = tagSpan ? tagSpan.textContent?.trim() : '';
+          
+          // Process the caption content, including math elements
+          let captionContent = ProcessNodeHelper.getElementHTML(figcaption);
+          captionContent = captionContent.replace(/<math.*?>(.*?)<\/math>/g, (match, mathContent, offset, string) => {
+            const mathElement = new DOMParser().parseFromString(match, 'text/html').body.firstChild as Element;
+            const latex = extractLatex(mathElement);
+            const prevChar = string[offset - 1] || '';
+            const nextChar = string[offset + match.length] || '';
+
+            const isStartOfLine = offset === 0 || /\s/.test(prevChar);
+            const isEndOfLine = offset + match.length === string.length || /\s/.test(nextChar);
+
+            const leftSpace = (!isStartOfLine && !/[\s$]/.test(prevChar)) ? ' ' : '';
+            const rightSpace = (!isEndOfLine && !/[\s$]/.test(nextChar)) ? ' ' : '';
+
+            return `${leftSpace}$${latex}$${rightSpace}`;
+          });
+
+          // Convert the processed caption content to markdown
+          const captionMarkdown = turndownService.turndown(captionContent);
+          
+          // Combine tag and processed caption
+          caption = `${tagText} ${captionMarkdown}`.trim();
+        }
+
+        // Handle references in the caption
+        caption = caption.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, href) => {
+            return `[${text}](${href})`;
+        });
+
+        return `![${alt}](${src})\n\n${caption}\n\n`;
+      }
+    });
+
+    // Use Obsidian format for YouTube embeds and tweets
+    turndownService.addRule('embedToMarkdown', {
+      filter: function (node: Node): boolean {
+        if (node instanceof HTMLIFrameElement) {
+          const src = node.getAttribute('src');
+          return !!src && (
+            !!src.match(/(?:youtube\.com|youtu\.be)/) ||
+            !!src.match(/(?:twitter\.com|x\.com)/)
+          );
+        }
+        return false;
+      },
+      replacement: function (content: string, node: Node): string {
+        if (node instanceof HTMLIFrameElement) {
+          const src = node.getAttribute('src');
+          if (src) {
+            const youtubeMatch = src.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:embed\/|watch\?v=)?([a-zA-Z0-9_-]+)/);
+            if (youtubeMatch && youtubeMatch[1]) {
+              return `![](https://www.youtube.com/watch?v=${youtubeMatch[1]})`;
+            }
+            const tweetMatch = src.match(/(?:twitter\.com|x\.com)\/.*?(?:status|statuses)\/(\d+)/);
+            if (tweetMatch && tweetMatch[1]) {
+              return `![](https://x.com/i/status/${tweetMatch[1]})`;
+            }
+          }
+        }
+        return content;
+      }
+    });
+
+    turndownService.addRule('highlight', {
+      filter: 'mark',
+      replacement: function(content) {
+        return '==' + content + '==';
+      }
+    });
+
+    turndownService.addRule('strikethrough', {
+      filter: (node: Node) => 
+        node.nodeName === 'DEL' || 
+        node.nodeName === 'S' || 
+        node.nodeName === 'STRIKE',
+      replacement: function(content) {
+        return '~~' + content + '~~';
+      }
+    });
+
+    // Add a new custom rule for complex link structures
+    turndownService.addRule('complexLinkStructure', {
+      filter: function (node, options) {
+        return (
+          node.nodeName === 'A' &&
+          node.childNodes.length > 1 &&
+          Array.from(node.childNodes).some(child => ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(child.nodeName))
+        );
+      },
+      replacement: function (content, node, options) {
+        if (!(node instanceof HTMLElement)) return content;
+        const href = node.getAttribute('href');
+        const title = node.getAttribute('title');
+        
+        // Extract the heading
+        const headingNode = node.querySelector('h1, h2, h3, h4, h5, h6');
+        const headingContent = headingNode ? turndownService.turndown(ProcessNodeHelper.getElementHTML(headingNode)) : '';
+        
+        // Remove the heading from the content
+        if (headingNode) {
+          headingNode.remove();
+        }
+        
+        // Convert the remaining content
+        const remainingContent = turndownService.turndown(ProcessNodeHelper.getElementHTML(node));
+        
+        // Construct the new markdown
+        let markdown = `${headingContent}\n\n${remainingContent}\n\n`;
+        if (href) {
+          markdown += `[View original](${href})`;
+          if (title) {
+            markdown += ` "${title}"`;
+          }
+        }
+        
+        return markdown;
+      }
+    });
+
+    turndownService.addRule('arXivEnumerate', {
+      filter: (node) => {
+        return node.nodeName === 'OL' && node.classList.contains('ltx_enumerate');
+      },
+      replacement: function(content, node) {
+        if (!(node instanceof HTMLElement)) return content;
+        
+        const items = Array.from(node.children).map((item, index) => {
+          if (item instanceof HTMLElement) {
+            const itemContent = ProcessNodeHelper.getElementHTML(item).replace(/^<span class="ltx_tag ltx_tag_item">\d+\.<\/span>\s*/, '');
+            return `${index + 1}. ${turndownService.turndown(itemContent)}`;
+          }
+          return '';
+        });
+        
+        return '\n\n' + items.join('\n\n') + '\n\n';
+      }
+    });
+
+    turndownService.addRule('removeHiddenElements', {
+      filter: function (node) {
+        return (
+          node.style.display === 'none'
+        );
+      },
+      replacement: function () {
+        return '';
+      }
+    });
+
+    turndownService.addRule('citations', {
+      filter: (node: Node): boolean => {
+        if (node instanceof Element) {
+          return (
+            (node.nodeName === 'SUP' && node.id.startsWith('fnref:'))
+          );
+        }
+        return false;
+      },
+      replacement: (content, node) => {
+        if (node instanceof HTMLElement) {
+          if (node.nodeName === 'SUP' && node.id.startsWith('fnref:')) {
+            const id = node.id.replace('fnref:', '');
+            // Extract only the primary number before any hyphen
+            const primaryNumber = id.split('-')[0];
+            return `[^${primaryNumber}]`;
+          }
+        }
+        return content;
+      }
+    });
+
+    // Footnotes list
+    turndownService.addRule('footnotesList', {
+      filter: (node: Node): boolean => {
+        if (node instanceof HTMLOListElement) {
+          return (
+            node.parentElement?.id === 'footnotes'
+          );
+        }
+        return false;
+      },
+      replacement: (content, node) => {
+        if (node instanceof HTMLElement) {
+          const references = Array.from(node.children).map(li => {
+            let id;
+            if (li.id.startsWith('fn:')) {
+              id = li.id.replace('fn:', '');
+            } else {
+              const match = li.id.split('/').pop()?.match(/cite_note-(.+)/);
+              id = match ? match[1] : li.id;
+            }
+            
+            // Remove the leading sup element if its content matches the footnote id
+            const supElement = li.querySelector('sup');
+            if (supElement && supElement.textContent?.trim() === id) {
+              supElement.remove();
+            }
+            
+            const referenceContent = turndownService.turndown(ProcessNodeHelper.getElementHTML(li));
+            // Remove the backlink from the footnote content
+            const cleanedContent = referenceContent.replace(/\s*↩︎$/, '').trim();
+            return `[^${id.toLowerCase()}]: ${cleanedContent}`;
+          });
+          return '\n\n' + references.join('\n\n') + '\n\n';
+        }
+        return content;
+      }
+    });
+
+    // General removal rules for varous website elements
+    turndownService.addRule('removals', {
+      filter: function (node) {
+        if (!(node instanceof HTMLElement)) return false;
+        // Remove the Defuddle backlink from the footnote content
+        if (node.getAttribute('href')?.includes('#fnref')) return true;
+        if (node.classList.contains('footnote-backref')) return true;
+        return false;
+      },
+      replacement: function (content, node) {
+        return '';
+      }
+    });
+
+    turndownService.addRule('handleTextNodesInTables', {
+      filter: function (node: Node): boolean {
+        return node.nodeType === Node.TEXT_NODE && 
+             node.parentNode !== null && 
+             node.parentNode.nodeName === 'TD';
+      },
+      replacement: function (content: string): string {
+        return content;
+      }
+    });
+
+    turndownService.addRule('preformattedCode', {
+      filter: (node) => {
+        return node.nodeName === 'PRE';
+      },
+      replacement: (content, node) => {
+        if (!(node instanceof HTMLElement)) return content;
+        
+        const codeElement = node.querySelector('code');
+        if (!codeElement) return content;
+        
+        const language = codeElement.getAttribute('data-lang') || '';
+        const code = codeElement.textContent || '';
+        
+        // Clean up the content and escape backticks
+        const cleanCode = code
+          .trim()
+          .replace(/`/g, '\\`');
+        
+        return `\n\`\`\`${language}\n${cleanCode}\n\`\`\`\n`;
+      }
+    });
+
+    turndownService.addRule('MathJax', {
+      filter: (node) => {
+        const isMjxContainer = node.nodeName.toLowerCase() === 'mjx-container';
+        return isMjxContainer;
+      },
+      replacement: (content, node) => {
+        if (!(node instanceof HTMLElement)) {
+          return content;
+        }
+
+        const assistiveMml = node.querySelector('mjx-assistive-mml');
+        if (!assistiveMml) {
+          return content;
+        }
+
+        const mathElement = assistiveMml.querySelector('math');
+        if (!mathElement) {
+          return content;
+        }
+
+        let latex;
+        try {
+          latex = MathMLToLaTeX.convert(mathElement.outerHTML);
+        } catch (error) {
+          console.error('Error converting MathML to LaTeX:', error);
+          return content;
+        }
+
+        // Check if it's an inline or block math element
+        const isBlock = mathElement.getAttribute('display') === 'block';
+
+        if (isBlock) {
+          return `\n$$\n${latex}\n$$\n`;
+        } else {
+          return `$${latex}$`;
+        }
+      }
+    });
+
+    turndownService.addRule('math', {
+      filter: (node) => {
+        return node.nodeName.toLowerCase() === 'math' || 
+          (node instanceof Element && node.classList && 
+          (node.classList.contains('mwe-math-element') || 
+          node.classList.contains('mwe-math-fallback-image-inline') || 
+          node.classList.contains('mwe-math-fallback-image-display')));
+      },
+      replacement: (content, node) => {
+        if (!(node instanceof Element)) return content;
+
+        let latex = extractLatex(node);
+
+        // Remove leading and trailing whitespace
+        latex = latex.trim();
+
+        // Check if the math element is within a table
+        const isInTable = node.closest('table') !== null;
+
+        // Check if it's an inline or block math element
+        if (!isInTable && (
+          node.getAttribute('display') === 'block' || 
+          node.classList.contains('mwe-math-fallback-image-display') || 
+          (node.parentElement && node.parentElement.classList.contains('mwe-math-element') && 
+          node.parentElement.previousElementSibling && 
+          node.parentElement.previousElementSibling.nodeName.toLowerCase() === 'p')
+        )) {
+          return `\n$$\n${latex}\n$$\n`;
+        } else {
+          // For inline math, ensure there's a space before and after only if needed
+          const prevNode = node.previousSibling;
+          const nextNode = node.nextSibling;
+          const prevChar = prevNode?.textContent?.slice(-1) || '';
+          const nextChar = nextNode?.textContent?.[0] || '';
+
+          const isStartOfLine = !prevNode || (prevNode.nodeType === Node.TEXT_NODE && prevNode.textContent?.trim() === '');
+          const isEndOfLine = !nextNode || (nextNode.nodeType === Node.TEXT_NODE && nextNode.textContent?.trim() === '');
+
+          const leftSpace = (!isStartOfLine && prevChar && !/[\s$]/.test(prevChar)) ? ' ' : '';
+          const rightSpace = (!isEndOfLine && nextChar && !/[\s$]/.test(nextChar)) ? ' ' : '';
+
+          return `${leftSpace}$${latex}$${rightSpace}`;
+        }
+      }
+    });
+
+    turndownService.addRule('katex', {
+      filter: (node) => {
+        return node instanceof HTMLElement && 
+           (node.classList.contains('math') || node.classList.contains('katex'));
+      },
+      replacement: (content, node) => {
+        if (!(node instanceof HTMLElement)) return content;
+
+        // Try to find the original LaTeX content
+        // 1. Check data-latex attribute
+        let latex = node.getAttribute('data-latex');
+        
+        // 2. If no data-latex, try to get from .katex-mathml
+        if (!latex) {
+          const mathml = node.querySelector('.katex-mathml annotation[encoding="application/x-tex"]');
+          latex = mathml?.textContent || '';
+        }
+
+        // 3. If still no content, use text content as fallback
+        if (!latex) {
+          latex = node.textContent?.trim() || '';
+        }
+
+        // Determine if it's an inline formula
+        const mathElement = node.querySelector('.katex-mathml math');
+        const isInline = node.classList.contains('math-inline') || 
+          (mathElement && mathElement.getAttribute('display') !== 'block');
+        
+        if (isInline) {
+          return `$${latex}$`;
+        } else {
+          return `\n$$\n${latex}\n$$\n`;
+        }
+      }
+    });
+
+    turndownService.addRule('callout', {
+      filter: (node) => {
+        return (
+          node.nodeName.toLowerCase() === 'div' && 
+          node.classList.contains('markdown-alert')
+        );
+      },
+      replacement: (content, node) => {
+        const element = node as HTMLElement;
+        
+        // Get alert type from the class (e.g., markdown-alert-note -> NOTE)
+        const alertClasses = Array.from(element.classList);
+        const typeClass = alertClasses.find(c => c.startsWith('markdown-alert-') && c !== 'markdown-alert');
+        const type = typeClass ? typeClass.replace('markdown-alert-', '').toUpperCase() : 'NOTE';
+
+        // Find the title element and content
+        const titleElement = element.querySelector('.markdown-alert-title');
+        const contentElement = element.querySelector('p:not(.markdown-alert-title)');
+        
+        // Extract content, removing the title from it if present
+        let alertContent = content;
+        if (titleElement && titleElement.textContent) {
+          alertContent = contentElement?.textContent || content.replace(titleElement.textContent, '');
+        }
+
+        // Format as Obsidian callout
+        return `\n> [!${type}]\n> ${alertContent.trim().replace(/\n/g, '\n> ')}\n`;
+      }
+    });
+
+    function handleNestedEquations(table: Element): string {
+      const mathElements = table.querySelectorAll('math[alttext]');
+      if (mathElements.length === 0) return '';
+
+      return Array.from(mathElements).map(mathElement => {
+        const alttext = mathElement.getAttribute('alttext');
+        if (alttext) {
+          // Check if it's an inline or block equation
+          const isInline = mathElement.closest('.ltx_eqn_inline') !== null;
+          return isInline ? `$${alttext.trim()}$` : `\n$$\n${alttext.trim()}\n$$`;
+        }
+        return '';
+      }).join('\n\n');
     }
 
-    const alt = element.getAttribute('alt') || '';
-    if (!src || this.seenImages.has(src)) return '';
-    
-    this.seenImages.add(src);
-    return `![${alt}](${src}?crossorigin=${encodeURIComponent(crossOrigin!)})`;
+    function cleanupTableHTML(table: HTMLTableElement): string {
+      const allowedAttributes = ['src', 'href', 'style', 'align', 'width', 'height', 'rowspan', 'colspan', 'bgcolor', 'scope', 'valign', 'headers'];
+      
+      const cleanElement = (element: Element) => {
+        Array.from(element.attributes).forEach(attr => {
+          if (!allowedAttributes.includes(attr.name)) {
+            element.removeAttribute(attr.name);
+          }
+        });
+        
+        element.childNodes.forEach(child => {
+          if (child instanceof Element) {
+            cleanElement(child);
+          }
+        });
+      };
+
+      // Create a clone of the table to avoid modifying the original DOM
+      const tableClone = table.cloneNode(true) as HTMLTableElement;
+      cleanElement(tableClone);
+
+      return tableClone.outerHTML;
+    }
+
+    function extractLatex(element: Element): string {
+      // Check if the element is a <math> element and has an alttext attribute
+      if (element.nodeName.toLowerCase() === 'math') {
+        let latex = element.getAttribute('data-latex');
+        let alttext = element.getAttribute('alttext');
+        if (latex) {
+          return latex.trim();
+        } else if (alttext) {
+          return alttext.trim();
+        }
+        console.log('No latex or alttext found for math element:', element);
+      }
+
+      // If not, look for a nested <math> element with alttext
+      const mathElement = element.querySelector('math[alttext]');
+      if (mathElement) {
+        const alttext = mathElement.getAttribute('alttext');
+        if (alttext) {
+          return alttext.trim();
+        }
+      }
+
+      const annotation = element.querySelector('annotation[encoding="application/x-tex"]');
+      if (annotation?.textContent) {
+        return annotation.textContent.trim();
+      }
+
+      const mathNode = element.nodeName.toLowerCase() === 'math' ? element : element.querySelector('math');
+      if (mathNode) {
+        return MathMLToLaTeX.convert(mathNode.outerHTML);
+      }
+
+      const imgNode = element.querySelector('img');
+      return imgNode?.getAttribute('alt') || '';
+    }
+
+    try {
+      let markdown = turndownService.turndown(processedContent);
+      console.debug('Markdown', 'Markdown conversion successful');
+
+      // Remove the title from the beginning of the content if it exists
+      const titleMatch = markdown.match(/^# .+\n+/);
+      if (titleMatch) {
+        markdown = markdown.slice(titleMatch[0].length);
+      }
+
+      // Remove any empty links e.g. [](example.com) that remain, along with surrounding newlines
+      // But don't affect image links like ![](image.jpg)
+      markdown = markdown.replace(/\n*(?<!!)\[]\([^)]+\)\n*/g, '');
+
+      // Remove any consecutive newlines more than two
+      markdown = markdown.replace(/\n{3,}/g, '\n\n');
+
+      // Append footnotes at the end of the document
+      if (Object.keys(this.footnotes).length > 0) {
+        markdown += '\n\n---\n\n';
+        for (const [id, content] of Object.entries(this.footnotes)) {
+          markdown += `[^${id}]: ${content}\n\n`;
+        }
+      }
+      
+      // Clear the footnotes object for the next conversion
+      Object.keys(this.footnotes).forEach(key => delete this.footnotes[key]);
+
+      return markdown.trim();
+    } catch (error) {
+      console.error('Error converting HTML to Markdown:', error);
+      console.log('Problematic content:', processedContent.substring(0, 1000) + '...');
+      return `Partial conversion completed with errors. Original HTML:\n\n${processedContent}`;
+    }
   }
 
-  private processIframe(element: HTMLElement): string {
-    const src = element.getAttribute('src');
-    return src ? `[Embedded content](${src})\n\n` : '';
-  }
-
-  private processVideo(element: HTMLElement): string {
-    const src = element.getAttribute('src');
-    return src ? `[Video content](${src})\n\n` : '';
-  }
-
-  private processCode(element: HTMLElement): string {
-    const content = element.textContent || '';
-    return `\`${content.trim()}\``;
-  }
-
-  private processPre(element: HTMLElement, baseUrl: string): string {
-    const content = Array.from(element.childNodes)
-      .map((child) => this.processNode(child, baseUrl))
-      .join('');
-    return `\`\`\`\n${content.trim()}\n\`\`\`\n\n`;
+  /**
+   * Helper function to safely get HTML content from an element
+   */
+  static getElementHTML(element: Element): string {
+    const serializer = new XMLSerializer();
+    let result = '';
+    Array.from(element.childNodes).forEach(node => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        result += serializer.serializeToString(node);
+      } else if (node.nodeType === Node.TEXT_NODE) {
+        result += node.textContent;
+      }
+    });
+    return result;
   }
 }

--- a/src/Extractors/string-utils.ts
+++ b/src/Extractors/string-utils.ts
@@ -1,0 +1,217 @@
+/*
+MIT License
+
+Copyright (c) 2024 Obsidian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+export function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function escapeMarkdown(str: string): string {
+	return str.replace(/([[\]])/g, '\\$1');
+}
+
+export function escapeValue(value: string): string {
+	return value.replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+export function unescapeValue(value: string): string {
+	return value.replace(/\\"/g, '"').replace(/\\n/g, '\n');
+}
+
+export function escapeDoubleQuotes(str: string): string {
+	return str.replace(/"/g, '\\"');
+}
+
+export function sanitizeFileName(fileName: string): string {
+	const platform = (navigator as any).userAgentData?.platform || navigator.platform || '';
+	const isWindows = /win/i.test(platform);
+	const isMac = /mac/i.test(platform);
+
+	// First remove Obsidian-specific characters that should be sanitized across all platforms
+	let sanitized = fileName.replace(/[#|\^\[\]]/g, '');
+
+	if (isWindows) {
+		sanitized = sanitized
+			.replace(/[<>:"\/\\?*\x00-\x1F]/g, '')
+			.replace(/^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i, '_$1$2')
+			.replace(/[\s.]+$/, '');
+	} else if (isMac) {
+		sanitized = sanitized
+			.replace(/[\/:\x00-\x1F]/g, '')
+			.replace(/^\./, '_');
+	} else {
+		// Linux and other systems
+		sanitized = sanitized
+			.replace(/[<>:"\/\\|?*\x00-\x1F]/g, '')
+			.replace(/^\./, '_');
+	}
+
+	// Common operations for all platforms
+	sanitized = sanitized
+		.replace(/^\.+/, '') // Remove leading periods
+		.trim()
+		.slice(0, 245); // Trim to 245 characters, leaving room to append ' 1.md'
+
+	// Ensure the file name is not empty
+	if (sanitized.length === 0) {
+		sanitized = 'Untitled';
+	}
+
+	return sanitized;
+}
+
+export function formatVariables(variables: { [key: string]: string }): string {
+	return Object.entries(variables)
+		.map(([key, value]) => {
+			// Remove the outer curly braces from the key
+			const cleanKey = key.replace(/^{{|}}$/g, '');
+
+			return `
+				<div class="variable-item is-collapsed">
+					<span class="variable-key" data-variable="${escapeHtml(key)}">${escapeHtml(cleanKey)}</span>
+					<span class="variable-value">${escapeHtml(value)}</span>
+					<span class="chevron-icon" aria-label="Expand">
+						<i data-lucide="chevron-right"></i>
+					</span>
+				</div>
+			`;
+		})
+		.join('');
+}
+
+export function escapeHtml(unsafe: string): string {
+	return unsafe
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}
+
+// Cases to handle:
+// Full URLs: https://example.com/x.png
+// URLs without protocol: //example.com/x.png
+// Relative URLs:
+// - x.png
+// - /x.png
+// - img/x.png
+// - ../x.png
+
+export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl: URL) {
+	const attributeValue = element.getAttribute(attributeName);
+	if (attributeValue) {
+		try {
+			// Create a new URL object from the base URL
+			const resolvedBaseUrl = new URL(baseUrl.href);
+			
+			// If the base URL points to a file, remove the filename to get the directory
+			if (!resolvedBaseUrl.pathname.endsWith('/')) {
+				resolvedBaseUrl.pathname = resolvedBaseUrl.pathname.substring(0, resolvedBaseUrl.pathname.lastIndexOf('/') + 1);
+			}
+			
+			const url = new URL(attributeValue, resolvedBaseUrl);
+			
+			if (!['http:', 'https:'].includes(url.protocol)) {
+				// Handle non-standard protocols (chrome-extension://, moz-extension://, brave://, etc.)
+				const parts = attributeValue.split('/');
+				const firstSegment = parts[2]; // The segment after the protocol
+
+				if (firstSegment && firstSegment.includes('.')) {
+					// If it looks like a domain, replace the non-standard protocol with the current page's protocol
+					const newUrl = `${baseUrl.protocol}//` + attributeValue.split('://')[1];
+					element.setAttribute(attributeName, newUrl);
+				} else {
+					// If it doesn't look like a domain it's probably the extension URL, remove the non-standard protocol part and use baseUrl
+					const path = parts.slice(3).join('/');
+					const newUrl = new URL(path, resolvedBaseUrl.origin + resolvedBaseUrl.pathname).href;
+					element.setAttribute(attributeName, newUrl);
+				}
+			} else {
+				// Handle other cases (relative URLs, protocol-relative URLs)
+				const newUrl = url.href;
+				element.setAttribute(attributeName, newUrl);
+			}
+		} catch (error) {
+			console.warn(`Failed to process URL: ${attributeValue}`, error);
+			element.setAttribute(attributeName, attributeValue);
+		}
+	}
+}
+
+export function processUrls(htmlContent: string, baseUrl: URL): string {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(htmlContent, 'text/html');
+	
+	// Handle relative URLs for both images and links
+	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'srcset', baseUrl));
+	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'src', baseUrl));
+	doc.querySelectorAll('a').forEach(link => makeUrlAbsolute(link, 'href', baseUrl));
+	
+	// Serialize back to HTML
+	const serializer = new XMLSerializer();
+	let result = '';
+	Array.from(doc.body.childNodes).forEach(node => {
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			result += serializer.serializeToString(node);
+		} else if (node.nodeType === Node.TEXT_NODE) {
+			result += node.textContent;
+		}
+	});
+	
+	return result;
+}
+
+export function formatDuration(ms: number): string {
+	if (ms < 1000) {
+		return `${Math.round(ms)}ms`;
+	} else {
+		return `${(ms / 1000).toFixed(2)}s`;
+	}
+}
+
+export function getDomain(url: string): string {
+	try {
+		const urlObj = new URL(url);
+		const hostname = urlObj.hostname;
+
+		// Handle local development URLs
+		if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname.match(/^(\d{1,3}\.){3}\d{1,3}$/)) {
+			return hostname;
+		}
+
+		const hostParts = hostname.split('.');
+		
+		// Handle special cases like co.uk, com.au, etc.
+		if (hostParts.length > 2) {
+			const lastTwo = hostParts.slice(-2).join('.');
+			if (lastTwo.match(/^(co|com|org|net|edu|gov|mil)\.[a-z]{2}$/)) {
+				return hostParts.slice(-3).join('.');
+			}
+		}
+		
+		return hostParts.slice(-2).join('.');
+	} catch (error) {
+		console.warn('Invalid URL:', url);
+		return '';
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,
+	"esModuleInterop": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
This PR massively improves the quality of the markdown conversion by copying code from the [Obsidian Web Clipper](https://github.com/obsidianmd/obsidian-clipper).

Notes:
- Obsidian Web Clipper is under MIT. All copied code contains the copyright notice, but it might be necessary to add a note to the README.
- Unlike readability, defuddle doesn't have an excerpt property, so it's no longer included.
- I haven't worked on this project before, so some code quality adjustments might be needed
- Fixes #34 